### PR TITLE
Ghosts respect walls in Scatter Mode Also

### DIFF
--- a/client/src/components/PacmanGame/PacmanGame.jsx
+++ b/client/src/components/PacmanGame/PacmanGame.jsx
@@ -6,7 +6,13 @@ import {
 } from '../../api/socketService';
 import GamePage from '../Layout/GamePage';
 import {
-  boardCorners, codeToEntity, entityToCode, getGhosts, getPacman, advanceFrameAfterTime,
+  boardCorners,
+  codeToEntity,
+  entityToCode,
+  getGhosts,
+  getPacman,
+  advanceFrameAfterTime,
+  boardTranspose,
 } from './constants';
 import {
   initSquareGridState,
@@ -149,7 +155,7 @@ class PacmanGame extends Component {
     moveGhostsCount += 1;
     const scatterEnd = scatterStart + 55;
     if (moveGhostsCount === scatterStart) {
-      const gridWithWeights = getGridwithWeights(gridState);
+      const gridWithWeights = getGridwithWeights(boardTranspose);
       const ghostsPath = ghosts
         .map((ghost, index) => chaseLocation(gridWithWeights, ghost, boardCorners[index]))
         .map(postion => postion.map(arr => ({ x: arr[0], y: arr[1] })));

--- a/client/src/components/PacmanGame/constants.js
+++ b/client/src/components/PacmanGame/constants.js
@@ -40,6 +40,8 @@ export const board = [
   [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
 ];
 
+export const boardTranspose = board[0].map((col, i) => board.map(row => row[i]));
+
 export const codeToEntity = (code) => {
   const entityMap = {
     0: 'free',
@@ -92,4 +94,4 @@ const framesPerSecond = 4;
 
 export const advanceFrameAfterTime = 1000 / framesPerSecond;
 
-export const entitiesAnimationDurationInSecond = 0.24;
+export const entitiesAnimationDurationInSecond = 0.10;


### PR DESCRIPTION
Fixes #106 by transposing `gridState` before sending to pathfinding functions.


![ghostRespectWall](https://user-images.githubusercontent.com/10586637/55256771-f0767800-5283-11e9-8587-93b767cd7d74.gif)
